### PR TITLE
fixing a problem in loading a sparks from the autoload inside the module config autoload.php file

### DIFF
--- a/static/install/mx/Modules.php.txt
+++ b/static/install/mx/Modules.php.txt
@@ -4,7 +4,7 @@ global $CFG;
 
 if(!defined('SPARKPATH'))
 {
-	define('SPARKPATH', APPPATH.'sparks/');
+	define('SPARKPATH', 'sparks/');
 }
 
 


### PR DESCRIPTION
if you keep the APPPATH in the define it will try to load something like this :
"application/sparks/layout/1.0.0/config/autoload.php" ( as example ), so to solve this
you must delet the APPPATH from the define statement
