### PR TITLE
Prevent PHP Error on $this->load->spark(array('spark1', 'spark2'));

### DIFF
--- a/application/core/MY_Loader.php
+++ b/application/core/MY_Loader.php
@@ -94,53 +94,56 @@ class MY_Loader extends CI_Loader
                 $this->spark($s);
             }
         }
-
-        $spark = ltrim($spark, '/');
-        $spark = rtrim($spark, '/');
-
-        $spark_path = SPARKPATH . $spark . '/';
-        $parts      = explode('/', $spark);
-        $spark_slug = strtolower($parts[0]);
-
-        # If we've already loaded this spark, bail
-        if(array_key_exists($spark_slug, $this->_ci_loaded_sparks))
+        else
         {
-            return true;
-        }
-
-        # Check that it exists. CI Doesn't check package existence by itself
-        if(!file_exists($spark_path))
-        {
-            show_error("Cannot find spark path at $spark_path");
-        }
-
-        if(count($parts) == 2)
-        {
-            $this->_ci_loaded_sparks[$spark_slug] = $spark;
-        }
-
-        $this->add_package_path($spark_path);
-
-        foreach($autoload as $type => $read)
-        {
-            if($type == 'library')
-                $this->library($read);
-            elseif($type == 'model')
-                $this->model($read);
-            elseif($type == 'config')
-                $this->config($read);
-            elseif($type == 'helper')
-                $this->helper($read);
-            elseif($type == 'view')
-                $this->view($read);
-            else
-                show_error ("Could not autoload object of type '$type' ($read) for spark $spark");
-        }
-
-        // Looks for a spark's specific autoloader
-        $this->ci_autoloader($spark_path);
-
-        return true;
+	
+	        $spark = ltrim($spark, '/');
+	        $spark = rtrim($spark, '/');
+	
+	        $spark_path = SPARKPATH . $spark . '/';
+	        $parts      = explode('/', $spark);
+	        $spark_slug = strtolower($parts[0]);
+	
+	        # If we've already loaded this spark, bail
+	        if(array_key_exists($spark_slug, $this->_ci_loaded_sparks))
+	        {
+	            return true;
+	        }
+	
+	        # Check that it exists. CI Doesn't check package existence by itself
+	        if(!file_exists($spark_path))
+	        {
+	            show_error("Cannot find spark path at $spark_path");
+	        }
+	
+	        if(count($parts) == 2)
+	        {
+	            $this->_ci_loaded_sparks[$spark_slug] = $spark;
+	        }
+	
+	        $this->add_package_path($spark_path);
+	
+	        foreach($autoload as $type => $read)
+	        {
+	            if($type == 'library')
+	                $this->library($read);
+	            elseif($type == 'model')
+	                $this->model($read);
+	            elseif($type == 'config')
+	                $this->config($read);
+	            elseif($type == 'helper')
+	                $this->helper($read);
+	            elseif($type == 'view')
+	                $this->view($read);
+	            else
+	                show_error ("Could not autoload object of type '$type' ($read) for spark $spark");
+	        }
+	
+	        // Looks for a spark's specific autoloader
+	        $this->ci_autoloader($spark_path);
+	
+	        return true;
+	    }
     }
 
 	/**


### PR DESCRIPTION
When loading multiple sparks via a passed array, MY_Loader.php will throw a PHP error:

```
A PHP Error was encountered
Severity: Warning

Message: ltrim() expects parameter 1 to be string, array given

Filename: core/MY_Loader.php

Line Number: 101

Backtrace:

File: /Library/WebServer/Documents/bookymark/application/core/MY_Loader.php
Line: 101
Function: ltrim

// etc. etc...
```

In the beginning of function spark($spark), if $spark is an array, it runs spark($spark) for each array item. **However it continues processing the spark load as if it's a single item** after that, which makes PHP mad. A simple "else" thrown in fixes this problem.
