### PR TITLE
Set show as default for package controller

### DIFF
--- a/application/config/routes.php
+++ b/application/config/routes.php
@@ -14,6 +14,7 @@ $route['packages/(:any)/versions/(:any)/enable']      = "packages/enable/$1/$2";
 $route['packages/(:any)/versions/(:any)/disable']     = "packages/disable/$1/$2";
 $route['packages/(:any)/show']                        = "packages/show/$1";
 $route['packages/(:any)/edit']                        = "packages/edit/$1";
+$route['packages/(:any)']                             = "packages/show/$1";
 $route['packages/add']                                = "packages/add";
 $route['packages/summary']                            = "packages/summary";
 $route['packages/search']                             = "packages/search";


### PR DESCRIPTION
less important but better concept for packages url
prevent   getsparks.org/packages/pack_name    to get 404 error..
